### PR TITLE
Corrected installation failure for requirements.txt

### DIFF
--- a/mysterium.py
+++ b/mysterium.py
@@ -16,9 +16,9 @@ except:
         if is_windows:
             output = ">nul"
         else:
-            output = "/dev/null"
+            output = "> /dev/null"
 
-        os.system(f"py -m pip install -r requirements.txt {output}")
+        os.system(f"python3 -m pip install -r requirements.txt {output}")
         import gratient, fade
     except:
         exit()


### PR DESCRIPTION
if not on windows the `output` variable was set to "/dev/null" which meant that /dev/null would be seen as a requirements.txt file for pip. I added the `> ` to pipe stdout to /dev/null instead of specifying it as a requirements.txt.  I also changed the command from `py` to `python3` because I've never seen the command `py` for python before and it didn't work on my system without symlinking `/bin/py→/bin/python3`.  I even installed a Window$ 10 VM to test if `python3` would work as a  command on Window$. It does.